### PR TITLE
feat: extract Modbus write operations and fix unique_id consistency

### DIFF
--- a/custom_components/solvis_control/binary_sensor.py
+++ b/custom_components/solvis_control/binary_sensor.py
@@ -155,13 +155,7 @@ class SolvisSensor(CoordinatorEntity, BinarySensorEntity):
         self.device_info = device_info
         self._attr_has_entity_name = True
         self.supported_version = supported_version
-        # cleaned_name = re.sub(r"[^A-Za-z0-9_-]+", "_", name)
-        # self.unique_id = f"{modbus_address}_{supported_version}_{cleaned_name}"
-        cleaned_name = re.sub(r"[^A-Za-z0-9_-]+", "_", name).strip("_")  # clean trailing "_"
-        if cleaned_name:
-            self.unique_id = f"{modbus_address}_{supported_version}_{cleaned_name}"
-        else:  # if name consists of special chars only
-            self.unique_id = f"{modbus_address}_{supported_version}"
+        self._attr_unique_id = generate_unique_id(modbus_address, supported_version, name)
         self.translation_key = name
         self.data_processing = data_processing
         self.poll_rate = poll_rate

--- a/custom_components/solvis_control/binary_sensor.py
+++ b/custom_components/solvis_control/binary_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_HOST, CONF_NAME, DATA_COORDINATOR, DOMAIN, DEVICE_VERSION, REGISTERS
 from .coordinator import SolvisModbusCoordinator
-from .utils.helpers import generate_device_info, conf_options_map
+from .utils.helpers import generate_device_info, conf_options_map, remove_old_entities, generate_unique_id, write_modbus_value
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/solvis_control/number.py
+++ b/custom_components/solvis_control/number.py
@@ -20,7 +20,7 @@ from pymodbus.exceptions import ConnectionException
 
 from .const import CONF_HOST, CONF_NAME, DATA_COORDINATOR, DOMAIN, REGISTERS, DEVICE_VERSION
 from .coordinator import SolvisModbusCoordinator
-from .utils.helpers import generate_device_info, conf_options_map, remove_old_entities, generate_unique_id
+from .utils.helpers import generate_device_info, conf_options_map, remove_old_entities, generate_unique_id, write_modbus_value
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -228,19 +228,6 @@ class SolvisNumber(NumberEntity, CoordinatorEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         modbus_value = int(value / self.multiplier)
-        try:
-            await self.coordinator.modbus.connect()
-            response = await self.coordinator.modbus.write_register(self.modbus_address, modbus_value, slave=1)
-            # Prüfe, ob die Antwort einen Fehler enthält
-            if response.isError():
-                raise Exception(f"Modbus error response: {response}")
-            _LOGGER.debug(f"[{self._response_key}] Successfully wrote value {modbus_value} to Modbus register {self.modbus_address}")
-
-        except ConnectionException as e:
-            _LOGGER.warning(f"[{self._response_key}] Couldn't connect to Modbus device: {e}")
-
-        except Exception as e:
-            _LOGGER.error(f"[{self._response_key}] Unexpected error while writing to Modbus: {e}")
-
-        finally:
-            self.coordinator.modbus.close()
+        success = await write_modbus_value(self.coordinator.modbus, self.modbus_address, modbus_value, self._response_key)
+        if not success:
+            _LOGGER.error(f"[{self._response_key}] Failed to write value {modbus_value} to register {self.modbus_address}")

--- a/custom_components/solvis_control/number.py
+++ b/custom_components/solvis_control/number.py
@@ -141,7 +141,7 @@ class SolvisNumber(NumberEntity, CoordinatorEntity):
         self.device_info = device_info
         self._attr_has_entity_name = True
         self.supported_version = supported_version
-        self.unique_id = generate_unique_id(modbus_address, supported_version, name)
+        self._attr_unique_id = generate_unique_id(modbus_address, supported_version, name)
         self.translation_key = name
 
         if step_size is not None:

--- a/custom_components/solvis_control/select.py
+++ b/custom_components/solvis_control/select.py
@@ -128,7 +128,7 @@ class SolvisSelect(CoordinatorEntity, SelectEntity):
         self.device_info = device_info
         self._attr_has_entity_name = True
         self.supported_version = supported_version
-        self.unique_id = generate_unique_id(modbus_address, supported_version, name)
+        self._attr_unique_id = generate_unique_id(modbus_address, supported_version, name)
         self.translation_key = name
         self._attr_current_option = None
         self._attr_options = options if options is not None else []  # Set the options for the select entity

--- a/custom_components/solvis_control/sensor.py
+++ b/custom_components/solvis_control/sensor.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import CONF_HOST, CONF_NAME, DATA_COORDINATOR, DOMAIN, DEVICE_VERSION, REGISTERS
 
 from .coordinator import SolvisModbusCoordinator
-from .utils.helpers import generate_device_info, conf_options_map
+from .utils.helpers import generate_device_info, conf_options_map, remove_old_entities, generate_unique_id, write_modbus_value
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/solvis_control/sensor.py
+++ b/custom_components/solvis_control/sensor.py
@@ -139,8 +139,7 @@ class SolvisSensor(CoordinatorEntity, SensorEntity):
         self.device_info = device_info
         self._attr_has_entity_name = True
         self.supported_version = supported_version
-        cleaned_name = re.sub(r"[^A-Za-z0-9_-]+", "_", name or "unknown")
-        self.unique_id = f"{modbus_address}_{supported_version}_{cleaned_name}"
+        self._attr_unique_id = generate_unique_id(modbus_address, supported_version, name)
         self.translation_key = name
         self.data_processing = data_processing
         self.poll_rate = poll_rate

--- a/custom_components/solvis_control/switch.py
+++ b/custom_components/solvis_control/switch.py
@@ -20,7 +20,7 @@ from pymodbus.exceptions import ConnectionException
 
 from .const import CONF_HOST, CONF_NAME, DATA_COORDINATOR, DOMAIN, DEVICE_VERSION, REGISTERS
 from .coordinator import SolvisModbusCoordinator
-from .utils.helpers import generate_device_info, conf_options_map
+from .utils.helpers import generate_device_info, conf_options_map, remove_old_entities, generate_unique_id, write_modbus_value
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -180,24 +180,18 @@ class SolvisSwitch(CoordinatorEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        try:
-            await self.coordinator.modbus.connect()
-            await self.coordinator.modbus.write_register(address=self.modbus_address, value=1, slave=1)
-        except ConnectionException:
-            _LOGGER.warning("Couldn't connect to device")
-        finally:
-            self.coordinator.modbus.close()
+        success = await write_modbus_value(self.coordinator.modbus, self.modbus_address, 1, self._response_key)
+        if success:
             self._attr_is_on = True
-            self.async_write_ha_state()
+        else:
+            _LOGGER.error(f"[{self._response_key}] Failed to turn on (write value 1) at register {self.modbus_address}")
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        try:
-            await self.coordinator.modbus.connect()
-            await self.coordinator.modbus.write_register(address=self.modbus_address, value=0, slave=1)
-        except ConnectionException:
-            _LOGGER.warning("Couldn't connect to device")
-        finally:
-            self.coordinator.modbus.close()
+        success = await write_modbus_value(self.coordinator.modbus, self.modbus_address, 0, self._response_key)
+        if success:
             self._attr_is_on = False
-            self.async_write_ha_state()
+        else:
+            _LOGGER.error(f"[{self._response_key}] Failed to turn off (write value 0) at register {self.modbus_address}")
+        self.async_write_ha_state()

--- a/custom_components/solvis_control/switch.py
+++ b/custom_components/solvis_control/switch.py
@@ -121,8 +121,7 @@ class SolvisSwitch(CoordinatorEntity, SwitchEntity):
         self.device_info = device_info
         self._attr_has_entity_name = True
         self.supported_version = supported_version
-        cleaned_name = re.sub(r"[^A-Za-z0-9_-]+", "_", name)
-        self.unique_id = f"{modbus_address}_{supported_version}_{cleaned_name}"
+        self._attr_unique_id = generate_unique_id(modbus_address, supported_version, name)
         self.translation_key = name
         self._attr_current_option = None
         self.data_processing = data_processing


### PR DESCRIPTION
Extracted Modbus write operations into a dedicated helper method (write_modbus_value).
Also fixed consistent setting of unique_id using ._attr_unique_id.

Step towards #159