### PR TITLE
fix(modbus): improve connection handling and error management

### DIFF
--- a/custom_components/solvis_control/config_flow.py
+++ b/custom_components/solvis_control/config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.helpers import selector
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.device_registry import format_mac
 
+from .utils.helpers import fetch_modbus_value, get_mac
 from .const import (
     CONF_HOST,
     CONF_NAME,
@@ -47,8 +48,6 @@ from .const import (
     POLL_RATE_HIGH,
     SolvisDeviceVersion,
 )
-from .utils.helpers import fetch_modbus_value
-from .utils.helpers import get_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -276,7 +275,7 @@ class SolvisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is None:  # before user inputs anything
 
             try:
-                amount_hkr = await fetch_modbus_value(2, 1, self.data[CONF_HOST], self.data[CONF_PORT])
+                amount_hkr = await fetch_modbus_value(2, 1, self.data[CONF_HOST], self.data[CONF_PORT], device_version=int(self.data.get(DEVICE_VERSION, 0)))
                 _LOGGER.debug(f"[config_flow > async_step_features] Register 2 read from Modbus: {amount_hkr}")
             except Exception as exc:
                 _LOGGER.warning("[config_flow > async_step_features] Got no value for register 2: setting default 1.")

--- a/custom_components/solvis_control/coordinator.py
+++ b/custom_components/solvis_control/coordinator.py
@@ -7,13 +7,15 @@ Version: v2.0.0
 import logging
 import struct
 from datetime import timedelta
+import asyncio
 
 import pymodbus
 from pymodbus.client import AsyncModbusTcpClient
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers import entity_registry as er
-from pymodbus.exceptions import ConnectionException, ModbusException
-
+from homeassistant.exceptions import ConfigEntryNotReady
+from pymodbus.exceptions import ConnectionException, ModbusException, ModbusIOException
+from .utils.helpers import conf_options_map_coordinator, should_skip_register, ensure_connected
 from .const import (
     CONF_HOST,
     CONF_PORT,
@@ -34,9 +36,8 @@ from .const import (
     POLL_RATE_SLOW,
     POLL_RATE_DEFAULT,
     POLL_RATE_HIGH,
+    REGISTERS,
 )
-from .const import REGISTERS
-from .utils.helpers import conf_options_map_coordinator, should_skip_register
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,91 +82,118 @@ class SolvisModbusCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Polling data...")
         parsed_data = {}
 
-        try:
-            if not self.modbus.connected:
-                await self.modbus.connect()
-            _LOGGER.debug("Connected to Modbus for Solvis")  # Moved here for better context
+        # SC2-devices: reconnect
+        if int(self.supported_version) == 2:
+            _LOGGER.debug("SC2-device: Modbus reconnect...")
 
-            for register in REGISTERS:
-                _LOGGER.debug(f"[{register.name} | {register.address}] Checking...")
-
-                if should_skip_register(self.config_entry.data, register):
-                    _LOGGER.debug(f"[{register.name} | {register.address}] Skipping register based on configuration and device version.")
-                    continue
-
-                # Calculation for passing entites, which are in SLOW_POLL_GROUP or STANDARD_POLL_GROUP
-                if register.poll_rate == 1:  # SLOW_POLL_GROUP
-                    if register.poll_time > 0:
-                        register.poll_time -= self.poll_rate_high  # formerly: self.poll_rate_default
-                        _LOGGER.debug(f"[{register.name} | {register.address}] Skipping entity due to slow poll rate. Remaining time: {register.poll_time}s")
-                        continue
-                    else:  # register.poll_time <= 0:
-                        register.poll_time = self.poll_rate_slow
-
-                elif register.poll_rate == 0:  # DEFAULT_POLL_GROUP
-                    if register.poll_time > 0:
-                        register.poll_time -= self.poll_rate_high
-                        _LOGGER.debug(f"[{register.name} | {register.address}] Skipping entity due to standard poll rate. Remaining time: {register.poll_time}s")
-                        continue
-                    else:  # if register.poll_time <= 0:
-                        register.poll_time = self.poll_rate_default
-
-                entity_id = f"{DOMAIN}.{register.name}"
-                entity_registry = er.async_get(self.hass)
-                entity_entry = entity_registry.entities.get(entity_id)
-
-                if entity_entry and entity_entry.disabled:
-                    _LOGGER.debug(f"[{register.name} | {register.address}] Skipping disabled entity")
-                    continue
-
-                try:
-                    if register.register == 1:  # read input registers
-                        result = await self.modbus.read_input_registers(address=register.address, count=1)
-                        _LOGGER.debug(f"[{register.name} | {register.address}] Reading input register")
-
-                    else:  # read holding registers
-                        result = await self.modbus.read_holding_registers(address=register.address, count=1)
-                        _LOGGER.debug(f"[{register.name} | {register.address}] Reading holding register")
-
-                    if isinstance(result, pymodbus.pdu.ExceptionResponse):  # better type checking
-                        _LOGGER.error(f"[{register.name} | {register.address}] Modbus error while reading register: {result}")
-                        continue
-
-                    if not result or not hasattr(result, "registers") or not result.registers:  # additionally check for invalid results
-                        _LOGGER.error(f"[{register.name} | {register.address}] Invalid Modbus response: {result}")
-                        continue
-
-                    try:
-                        data_from_register = self.modbus.convert_from_registers(registers=result.registers, data_type=self.modbus.DATATYPE.INT16, word_order="big")
-
-                        if register.byte_swap == 1:  # little endian
-                            _LOGGER.debug(f"[{register.name} | {register.address}] Converting to Little Endian: {data_from_register}")
-                            data_from_register = struct.unpack("<h", struct.pack(">h", data_from_register))[0]
-
-                        _LOGGER.debug(f"[{register.name} | {register.address}] Raw value: {data_from_register}")
-
-                        value = round(data_from_register * register.multiplier, 2)
-                        parsed_data[register.name] = abs(value) if register.absolute_value else value
-
-                    except (struct.error, ValueError) as err:
-                        _LOGGER.error(f"[{register.name} | {register.address}] Data conversion error: {err}")
-                        parsed_data[register.name] = -300
-
-                except ModbusException as error:
-                    _LOGGER.error(f"[{register.name} | {register.address}] Modbus error while reading register: {error}")
-
-        except ConnectionException:
-            _LOGGER.warning("Couldn't connect to Solvis device.")
-
-        finally:
             try:
                 self.modbus.close()
-                _LOGGER.debug("Modbus for Solvis disconnected.")
+                await asyncio.sleep(0.1)
+                connected = await self.modbus.connect()
+                await asyncio.sleep(0.1)
 
-            except Exception as e:
-                _LOGGER.error(f"Error while closing modbus: {e}")
+                if not connected:
+                    raise RuntimeError("Modbus (re)connect failed: connect() returned False")
 
-        _LOGGER.debug(f"Parsed data keys: {list(parsed_data.keys())}")
+                _LOGGER.debug("SC2-device: Modbus reconnected")
+
+            except (ConnectionException, ModbusIOException, ModbusException) as err:
+                _LOGGER.error("Modbus connect failed: %s", err)
+                raise ConfigEntryNotReady("Solvis Control not reachable. Try again later...") from err
+
+        # check connection
+        if not await ensure_connected(self.modbus):
+            _LOGGER.error("Initial Modbus (re)connect failed, aborting update")
+            raise UpdateFailed("Initial Modbus (re)connect failed")
+
+        for register in REGISTERS:
+            _LOGGER.debug(f"[{register.name} | {register.address}] Checking...")
+
+            # skip by config or device version
+            if should_skip_register(self.config_entry.data, register):
+                _LOGGER.debug(f"[{register.name} | {register.address}] Skipping register based on configuration and device version.")
+                continue
+
+            # Calculation for passing entites, which are in SLOW_POLL_GROUP or STANDARD_POLL_GROUP
+            if register.poll_rate == 1:  # SLOW_POLL_GROUP
+                if register.poll_time > 0:
+                    register.poll_time -= self.poll_rate_high  # formerly: self.poll_rate_default
+                    _LOGGER.debug(f"[{register.name} | {register.address}] Skipping entity due to slow poll rate. Remaining time: {register.poll_time}s")
+                    continue
+                else:  # register.poll_time <= 0:
+                    register.poll_time = self.poll_rate_slow
+
+            elif register.poll_rate == 0:  # DEFAULT_POLL_GROUP
+                if register.poll_time > 0:
+                    register.poll_time -= self.poll_rate_high
+                    _LOGGER.debug(f"[{register.name} | {register.address}] Skipping entity due to standard poll rate. Remaining time: {register.poll_time}s")
+                    continue
+                else:  # if register.poll_time <= 0:
+                    register.poll_time = self.poll_rate_default
+
+            entity_id = f"{DOMAIN}.{register.name}"
+            entity_registry = er.async_get(self.hass)
+            entity_entry = entity_registry.entities.get(entity_id)
+
+            # skip disabled entities
+            if entity_entry and entity_entry.disabled:
+                _LOGGER.debug(f"[{register.name} | {register.address}] Skipping disabled entity")
+                continue
+
+            # check connection / reconnect
+            if not await ensure_connected(self.modbus):
+                _LOGGER.error(f"[{register.name} | {register.address}] Skipping read: no connection")
+                continue
+
+            # READ
+            try:
+                # read input registers
+                if register.register == 1:
+                    _LOGGER.debug(f"[{register.name} | {register.address}] Reading input register...")
+                    result = await self.modbus.read_input_registers(address=register.address, count=1)
+
+                # read holding registers
+                else:
+                    _LOGGER.debug(f"[{register.name} | {register.address}] Reading holding register...")
+                    result = await self.modbus.read_holding_registers(address=register.address, count=1)
+
+                # slow down on SC2-devices
+                if int(self.supported_version) == 2:
+                    _LOGGER.debug(f"[{register.name} | {register.address}] Sleep after read (SC2)")
+                    await asyncio.sleep(0.3)
+
+            except (ConnectionException, ModbusIOException, ModbusException) as err:
+                _LOGGER.error(f"[{register.name} | {register.address}] Exception during read: {err} - skipping read")
+                raise UpdateFailed(f"[{register.name} | {register.address}] Exception during read") from err
+
+            # check for error response
+            if not result or hasattr(result, "isError") and result.isError():
+                _LOGGER.error(f"[{register.name} | {register.address}] Modbus error while reading register: {result}")
+                raise UpdateFailed(f"[{register.name} | {register.address}] Modbus error while reading register")
+
+            # check for invalid results
+            if not hasattr(result, "registers") or not result.registers:
+                _LOGGER.error(f"[{register.name} | {register.address}] Invalid Modbus response: {result}")
+                raise UpdateFailed(f"[{register.name} | {register.address}] Invalid Modbus response")
+
+            # conversion
+            try:
+                data_from_register = self.modbus.convert_from_registers(registers=result.registers, data_type=self.modbus.DATATYPE.INT16, word_order="big")
+
+                if register.byte_swap == 1:  # little endian
+                    _LOGGER.debug(f"[{register.name} | {register.address}] Converting to Little Endian: {data_from_register}")
+                    data_from_register = struct.unpack("<h", struct.pack(">h", data_from_register))[0]
+
+                _LOGGER.debug(f"[{register.name} | {register.address}] Raw value: {data_from_register}")
+
+                value = round(data_from_register * register.multiplier, 2)
+                parsed_data[register.name] = abs(value) if register.absolute_value else value
+
+            except (struct.error, ValueError) as err:
+                _LOGGER.error(f"[{register.name} | {register.address}] Data conversion error: {err}")
+                parsed_data[register.name] = -300
+                raise UpdateFailed(f"[{register.name} | {register.address}] Data conversion error") from err
+
         _LOGGER.debug(f"Returned data: {parsed_data}")
 
         return parsed_data

--- a/custom_components/solvis_control/diagnostics.py
+++ b/custom_components/solvis_control/diagnostics.py
@@ -6,34 +6,45 @@ Version: v2.0.0
 
 from typing import Any
 
-import pymodbus.client as ModbusClient
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from pymodbus.exceptions import ModbusException
+from pymodbus.exceptions import ModbusException, ConnectionException
 from custom_components.solvis_control.const import REGISTERS
+
+import pymodbus.client as ModbusClient
+
+AsyncModbusTcpClient = ModbusClient.AsyncModbusTcpClient
 
 
 async def scan_modbus_registers(host: str, port: int, register_type: int) -> dict[str, Any]:
     """Scan Modbus registers defined in REGISTERS for the given register type and return their values."""
     addresses = sorted({r.address for r in REGISTERS if r.register == register_type})
     result = {}
-    client = ModbusClient.AsyncModbusTcpClient(host=host, port=port)
-    try:
-        await client.connect()
+
+    async with AsyncModbusTcpClient(
+        host=host,
+        port=port,
+        timeout=5.0,
+        retries=3,
+        reconnect_delay=1.0,
+        reconnect_delay_max=10.0,
+    ) as client:
         for address in addresses:
-            if register_type == 1:
-                response = await client.read_input_registers(address=address, count=1)
-            else:
-                response = await client.read_holding_registers(address=address, count=1)
-            if response.isError():
+            try:
+                if register_type == 1:
+                    response = await client.read_input_registers(address=address, count=1)
+                else:
+                    response = await client.read_holding_registers(address=address, count=1)
+            except ConnectionException as exc:
+                result["error"] = str(exc)
+                continue
+
+            if not response or response.isError():
                 result[f"register_{address}"] = "Error"
             else:
                 decoder = client.convert_from_registers(response.registers, data_type=client.DATATYPE.INT16, word_order="big")
                 result[f"register_{address}"] = float(decoder)
-    except ModbusException as exc:
-        result["error"] = str(exc)
-    finally:
-        client.close()
+
     return result
 
 

--- a/custom_components/solvis_control/manifest.json
+++ b/custom_components/solvis_control/manifest.json
@@ -9,5 +9,5 @@
 	"iot_class": "local_polling",
 	"issue_tracker": "https://github.com/LarsK1/hass_solvis_control/issues",
     "requirements": ["pymodbus>=3.9.2", "scapy>=2.6.1"],
-    "version": "2.0.1"
+    "version": "2.0.2"
   }

--- a/custom_components/solvis_control/utils/helpers.py
+++ b/custom_components/solvis_control/utils/helpers.py
@@ -6,6 +6,7 @@ Version: v2.0.0
 
 import logging
 import re
+import socket
 
 from decimal import Decimal
 from homeassistant.core import HomeAssistant
@@ -16,7 +17,7 @@ from homeassistant.helpers.entity_registry import async_resolve_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from scapy.all import ARP, Ether, srp
 from pymodbus.exceptions import ConnectionException, ModbusException
-import pymodbus.client as ModbusClient
+from pymodbus.client import AsyncModbusTcpClient
 
 from custom_components.solvis_control.const import (
     CONF_NAME,
@@ -79,7 +80,15 @@ def generate_device_info(entry: ConfigEntry, host: str, name: str) -> DeviceInfo
     return DeviceInfo(**info)
 
 
-async def fetch_modbus_value(register, register_type, host: str, port: int, datatype="INT16", order="big") -> int | list[int] | None:
+async def fetch_modbus_value(
+    register,
+    register_type,
+    host: str,
+    port: int,
+    device_version: int = 0,
+    datatype="INT16",
+    order="big",
+) -> int | list[int] | None:
     """
     Fetch one or multiple values from the Modbus device.
     If 'register' is an int, returns a single value.
@@ -93,53 +102,31 @@ async def fetch_modbus_value(register, register_type, host: str, port: int, data
     else:
         registers = register
 
-    modbussocket = None
-    try:
-        _LOGGER.debug(f"[fetch_modbus_value] Creating Modbus client for {host}:{port}")
+    results = []
 
-        modbussocket = ModbusClient.AsyncModbusTcpClient(host=host, port=port)
-
-        if modbussocket is None:
-            raise ConnectionException(f"[fetch_modbus_value] Failed to initialize Modbus client for {host}:{port}")
-
-        _LOGGER.debug(f"[fetch_modbus_value] Modbus client created: {modbussocket}")
-        connected = await modbussocket.connect()
-
-        if not connected:
-            raise ConnectionException(f"[fetch_modbus_value] Failed to connect to Modbus device at {host}:{port}")
-
-        _LOGGER.debug("[fetch_modbus_value] Connected to Modbus for Solvis")
-
-        results = []
+    async with create_modbus_client(
+        host=host,
+        port=port,
+        device_version=device_version,
+    ) as client:
 
         for reg in registers:
             if register_type == 1:
-                data = await modbussocket.read_input_registers(address=reg, count=1)
+                data = await client.read_input_registers(address=reg, count=1)
             else:
-                data = await modbussocket.read_holding_registers(address=reg, count=1)
+                data = await client.read_holding_registers(address=reg, count=1)
 
-            if not data or not hasattr(data, "registers") or not data.registers:
+            if not data or not hasattr(data, "registers") or data.isError():
                 raise ModbusException(f"[fetch_modbus_value] Invalid response from Modbus for register {reg} at {host}:{port}")
 
-            value = modbussocket.convert_from_registers(
+            value = client.convert_from_registers(
                 data.registers,
-                data_type=modbussocket.DATATYPE.INT16,
+                data_type=client.DATATYPE.INT16,
                 word_order=order,
             )
             results.append(value)
 
         return results[0] if single else results
-
-    finally:
-        if modbussocket:
-            try:
-                _LOGGER.debug(f"[fetch_modbus_value] Closing Modbus connection: {modbussocket}")
-                modbussocket.close()
-                _LOGGER.debug("[fetch_modbus_value] Modbus connection closed")
-            except Exception as e:
-                _LOGGER.warning(f"[fetch_modbus_value] Error while closing Modbus connection: {e}")
-        else:
-            _LOGGER.warning("[fetch_modbus_value] Modbus client was None before closing!")
 
 
 conf_options_map = {
@@ -224,14 +211,16 @@ def generate_unique_id(modbus_address: int, supported_version: int, name: str) -
 
 async def write_modbus_value(modbus, address: int, value: int, response_key: str = None) -> bool:
     """Write a value to a Modbus register."""
-    try:
-        _LOGGER.debug(f"[write_modbus_value] Using Modbus client: {modbus}")
-        connected = await modbus.connect()
-        if not connected:
-            _LOGGER.error(f"[write_modbus_value] Failed to connect to Modbus device")
-            return False
 
-        _LOGGER.debug("[write_modbus_value] Connected to Modbus device")
+    _LOGGER.debug(f"[write_modbus_value] Using Modbus client: {modbus}")
+
+    if not await ensure_connected(modbus):
+        _LOGGER.error("[write_modbus_value] Cannot connect to Modbus")
+        return False
+
+    _LOGGER.debug("[write_modbus_value] Connected to Modbus device")
+
+    try:
         response = await modbus.write_register(address, value, slave=1)
         if response.isError():
             _LOGGER.error(f"[write_modbus_value] Modbus error response for register {address}: {response}")
@@ -249,13 +238,6 @@ async def write_modbus_value(modbus, address: int, value: int, response_key: str
     except Exception as e:
         _LOGGER.error(f"[write_modbus_value] Unexpected error: {e}")
         return False
-    finally:
-        try:
-            _LOGGER.debug("[write_modbus_value] Closing Modbus connection")
-            modbus.close()
-            _LOGGER.debug("[write_modbus_value] Modbus connection closed")
-        except Exception as e:
-            _LOGGER.warning(f"[write_modbus_value] Error while closing Modbus connection: {e}")
 
 
 def process_coordinator_data(coordinator_data: dict, response_key: str):
@@ -412,3 +394,47 @@ async def async_setup_solvis_entities(
 
     async_add_entities(entities)
     _LOGGER.info(f"Successfully added {len(entities)} entities")
+
+
+async def ensure_connected(client) -> bool:
+    """
+    Ensure the Modbus client is connected.
+    If not, attempt one reconnect and return success state.
+    """
+    if not client.connected:
+        _LOGGER.debug("Modbus client not connected. Reconnecting...")
+        try:
+            await client.connect()
+            _LOGGER.debug("Modbus reconnect successful")
+        except ConnectionException as e:
+            _LOGGER.error(f"Modbus reconnect failed: {e}")
+            return False
+    return True
+
+
+def create_modbus_client(
+    host: str,
+    port: int,
+    device_version: int = None,
+    timeout: float = 2.0,
+    retries: int = 1,
+    reconnect_delay: float = 0.5,
+    reconnect_delay_max: float = 5.0,
+) -> AsyncModbusTcpClient:
+    """Create AsyncModbusTcpClient; for SC2 devices (device_version==2) use slower, more stable defaults."""
+
+    # adjust for SC2
+    if device_version == 2:
+        timeout = 6.0
+        retries = 3
+        reconnect_delay = 1.0
+        reconnect_delay_max = 5.0
+
+    return AsyncModbusTcpClient(
+        host=host,
+        port=port,
+        timeout=timeout,
+        retries=retries,
+        reconnect_delay=reconnect_delay,
+        reconnect_delay_max=reconnect_delay_max,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import logging
 from tests.dummies import DummyConfigEntry, DummyEntity, DummyEntityRegistry, DummyRegister
 from tests.dummies import DummyModbusClient, DummyModbusResponse, DummyResponseObj
 from homeassistant.util import dt as dt_util
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock, PropertyMock
 from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.exceptions import ConnectionException, ModbusException
 from custom_components.solvis_control.coordinator import SolvisModbusCoordinator
@@ -87,6 +87,8 @@ def mock_modbus(mocker, request):
     def mock_modbus_factory(host="127.0.0.1", port=502):
         _LOGGER.debug(f"[mock_modbus_factory] Creating Mock-Modbus-Client for {host}:{port} with parameters: {locals()}")
         mock_modbus_client = AsyncMock(spec=AsyncModbusTcpClient)
+        mock_modbus_client.__aenter__.return_value = mock_modbus_client
+        mock_modbus_client.__aexit__.return_value = None
         mock_modbus_client.host = host
         mock_modbus_client.port = port
         mock_modbus_client.DATATYPE = type("DATATYPE", (), {"INT16": "int16"})
@@ -108,6 +110,7 @@ def mock_modbus(mocker, request):
                     raise ConnectionException("Connection failed")
 
                 mock_modbus_client.connect.side_effect = failing_connect
+                type(mock_modbus_client).connected = PropertyMock(return_value=False)
 
             else:
                 mock_modbus_client.connect.side_effect = mock_connect
@@ -124,13 +127,14 @@ def mock_modbus(mocker, request):
                 custom_registers = custom_registers or {}
 
                 async def custom_read_registers(address, count):
-                    response_mock = AsyncMock()
+                    response_mock = MagicMock()
+
+                    response_mock.isError.return_value = False
 
                     if address in custom_registers:
                         response_mock.registers = custom_registers[address]
                     else:
                         response_mock.registers = [10001]
-
                     return response_mock
 
                 mock_modbus_client.read_input_registers.side_effect = custom_read_registers
@@ -163,7 +167,7 @@ def mock_modbus(mocker, request):
 
     patch_targets = [
         "pymodbus.client.AsyncModbusTcpClient",
-        "custom_components.solvis_control.utils.helpers.ModbusClient.AsyncModbusTcpClient",
+        "custom_components.solvis_control.utils.helpers.AsyncModbusTcpClient",
         "custom_components.solvis_control.config_flow.ModbusClient.AsyncModbusTcpClient",
     ]
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -9,8 +9,10 @@ import struct
 import pytest
 from unittest.mock import MagicMock
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.exceptions import ConfigEntryNotReady
 from custom_components.solvis_control.coordinator import SolvisModbusCoordinator
-from pymodbus.exceptions import ConnectionException, ModbusException
+from pymodbus.exceptions import ConnectionException, ModbusException, ModbusIOException
 from pymodbus.pdu import ExceptionResponse
 from tests.dummies import DummyConfigEntry, DummyEntity, DummyEntityRegistry, DummyRegister
 from tests.dummies import DummyModbusClient, DummyModbusResponse, DummyResponseObj
@@ -105,11 +107,10 @@ async def test_async_update_data_invalid_response(dummy_coordinator, monkeypatch
 
         return DummyResponse()
 
-    dummy_modbus = dummy_coordinator.modbus
-    dummy_modbus.read_input_registers = invalid_read
-    data = await dummy_coordinator._async_update_data()
+    dummy_coordinator.modbus.read_input_registers = invalid_read
 
-    assert "invalid_sensor" not in data
+    with pytest.raises(UpdateFailed):
+        await dummy_coordinator._async_update_data()
 
 
 @pytest.mark.asyncio
@@ -131,11 +132,10 @@ async def test_async_update_data_modbus_exception(dummy_coordinator, monkeypatch
     async def raise_exception(address, count):
         raise ModbusException("Test modbus error")
 
-    dummy_modbus = dummy_coordinator.modbus
-    dummy_modbus.read_input_registers = raise_exception
-    data = await dummy_coordinator._async_update_data()
+    dummy_coordinator.modbus.read_input_registers = raise_exception
 
-    assert "error_sensor" not in data
+    with pytest.raises(UpdateFailed):
+        await dummy_coordinator._async_update_data()
 
 
 @pytest.mark.asyncio
@@ -220,17 +220,16 @@ async def test_exception_response(dummy_coordinator, monkeypatch):
     monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [dummy_register])
 
     class DummyExceptionResponse:
-        pass
-
-    dummy_modbus = dummy_coordinator.modbus
+        def isError(self):
+            return True
 
     async def exception_response(address, count):
         return DummyExceptionResponse()
 
-    dummy_modbus.read_input_registers = exception_response
-    entity_id = f"{dummy_register.name}"
-    data = await dummy_coordinator._async_update_data()
-    assert entity_id not in data
+    dummy_coordinator.modbus.read_input_registers = exception_response
+
+    with pytest.raises(UpdateFailed):
+        await dummy_coordinator._async_update_data()
 
 
 @pytest.mark.asyncio
@@ -248,79 +247,109 @@ async def test_data_conversion_error(dummy_coordinator, monkeypatch):
         byte_swap=0,
     )
     monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [dummy_register])
-    dummy_modbus = dummy_coordinator.modbus
 
     def raise_value_error(registers, data_type, word_order):
         raise ValueError("Conversion error")
 
-    dummy_modbus.convert_from_registers = raise_value_error
-    entity_id = f"{dummy_register.name}"
-    data = await dummy_coordinator._async_update_data()
-    assert entity_id in data
-    assert data[entity_id] == -300
+    dummy_coordinator.modbus.convert_from_registers = raise_value_error
+
+    with pytest.raises(UpdateFailed):
+        await dummy_coordinator._async_update_data()
 
 
 @pytest.mark.asyncio
-async def test_connection_exception(dummy_coordinator, monkeypatch):
-    dummy_modbus = dummy_coordinator.modbus
+async def test_sc2_reconnect_success(monkeypatch, dummy_coordinator):
+    # SC2 reconnect: close + connect(True) + kein Fehler
+    dummy_coordinator.supported_version = 2
+    monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [])
+    sleeps = []
 
-    async def raise_connection_exception():
-        raise ConnectionException("Connection failed")
+    async def fake_sleep(sec):
+        sleeps.append(sec)
 
-    dummy_modbus.connect = raise_connection_exception
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
     data = await dummy_coordinator._async_update_data()
+
+    assert dummy_coordinator.modbus.called_close is True
+    assert sleeps == [0.1, 0.1]
     assert data == {}
 
 
 @pytest.mark.asyncio
-async def test_close_exception(dummy_coordinator, monkeypatch):
-    dummy_register = DummyRegister(
-        name="normal_sensor",
-        address=800,
-        conf_option=0,
-        supported_version=1,
-        poll_rate=0,
-        poll_time=0,
-        reg=1,
-        multiplier=1.0,
-        absolute_value=False,
-        byte_swap=0,
-    )
-    monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [dummy_register])
-    dummy_modbus = dummy_coordinator.modbus
+async def test_sc2_reconnect_false_raises_runtime(monkeypatch, dummy_coordinator):
+    # SC2 reconnect: connect() -> False → RuntimeError
+    dummy_coordinator.supported_version = 2
+    monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [])
 
-    def raise_exception():
-        raise Exception("Close error")
+    async def connect_false():
+        return False
 
-    dummy_modbus.close = raise_exception
-    entity_id = f"{dummy_register.name}"
+    dummy_coordinator.modbus.connect = connect_false
 
-    data = await dummy_coordinator._async_update_data()
-    assert entity_id in data
-    assert data[entity_id] == 123
+    with pytest.raises(RuntimeError):
+        await dummy_coordinator._async_update_data()
 
 
 @pytest.mark.asyncio
-async def test_exception_response_instance(dummy_coordinator, monkeypatch):
-    dummy_register = DummyRegister(
-        name="exception_sensor_real",
-        address=600,
-        conf_option=0,
-        supported_version=1,
-        poll_rate=0,
-        poll_time=0,
-        reg=1,
-        multiplier=1.0,
-        absolute_value=False,
-        byte_swap=0,
-    )
-    monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [dummy_register])
+async def test_sc2_reconnect_exception_raises_configentry(monkeypatch, dummy_coordinator):
+    # SC2 reconnect: ConnectionException → ConfigEntryNotReady
+    dummy_coordinator.supported_version = 2
+    monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [])
 
-    async def exception_response(address, count):
-        return ExceptionResponse(1)
+    async def connect_fail():
+        raise ConnectionException("fail")
 
-    dummy_modbus = dummy_coordinator.modbus
-    dummy_modbus.read_input_registers = exception_response
+    dummy_coordinator.modbus.connect = connect_fail
+
+    with pytest.raises(ConfigEntryNotReady):
+        await dummy_coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_initial_reconnect_failed_raises_updatefailed(monkeypatch, dummy_coordinator):
+    # Initial ensure_connected → False → UpdateFailed
+    dummy_coordinator.supported_version = 1
+    monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [])
+
+    dummy_coordinator.modbus.connected = False
+    dummy_coordinator.modbus.raise_on_connect = True
+
+    with pytest.raises(UpdateFailed):
+        await dummy_coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_skip_read_on_lost_connection(monkeypatch, dummy_coordinator, patch_registers):
+    # Inside loop: 2. ensure_connected → False → überspringen, kein Fehler
+    dummy_coordinator.supported_version = 1
+    calls = 0
+
+    async def fake_ensure(client):
+        nonlocal calls
+        calls += 1
+        return calls == 1  # 1. call ok, 2. call False
+
+    monkeypatch.setattr("custom_components.solvis_control.coordinator.ensure_connected", fake_ensure)
+    monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [patch_registers])
 
     data = await dummy_coordinator._async_update_data()
-    assert dummy_register.name not in data
+    assert patch_registers.name not in data
+
+
+@pytest.mark.asyncio
+async def test_sc2_sleep_after_read(monkeypatch, dummy_coordinator, patch_registers):
+    # SC2: nach read Sleep(0.3)
+    dummy_coordinator.supported_version = 2
+    monkeypatch.setattr("custom_components.solvis_control.coordinator.REGISTERS", [patch_registers])
+    sleeps = []
+
+    async def fake_sleep(sec):
+        sleeps.append(sec)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    data = await dummy_coordinator._async_update_data()
+
+    assert sleeps == [0.1, 0.1, 0.3]
+    assert patch_registers.name in data

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,10 +6,12 @@ Version: v2.0.0
 
 import pytest
 import pymodbus.client as ModbusClient
+import custom_components.solvis_control.diagnostics as diagnostics
 
-from pymodbus.exceptions import ModbusException
+from pymodbus.exceptions import ModbusException, ConnectionException
 from custom_components.solvis_control.diagnostics import scan_modbus_registers, async_get_config_entry_diagnostics
 from custom_components.solvis_control.const import REGISTERS
+from contextlib import asynccontextmanager
 
 
 class DummyResponse:
@@ -44,6 +46,11 @@ class DummyClient:
         pass
 
 
+class ErrorClient(DummyClient):
+    async def read_input_registers(self, address, count):
+        return DummyResponse(True, [])
+
+
 class ExceptionClient:
     DATATYPE = type("DummyDataType", (), {"INT16": "int16"})
 
@@ -54,6 +61,54 @@ class ExceptionClient:
         pass
 
 
+class ErrorReadClient(DummyClient):
+    async def read_input_registers(self, address, count):
+        raise ConnectionException("Test Modbus failure")
+
+
+@asynccontextmanager
+async def error_read_client_cm(host, port, **kwargs):
+    client = ErrorReadClient(host, port)
+    await client.connect()
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@asynccontextmanager
+async def dummy_client_cm(host, port, **kwargs):
+    client = DummyClient(host, port)
+    await client.connect()
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@asynccontextmanager
+async def error_client_cm(host, port, **kwargs):
+    client = ErrorClient(host, port)
+    await client.connect()
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@asynccontextmanager
+async def exception_client_cm(host, port, **kwargs):
+    client = ExceptionClient()
+    try:
+        await client.connect()
+    except ModbusException:
+        pass
+    try:
+        yield client
+    finally:
+        client.close()
+
+
 @pytest.mark.asyncio
 async def test_scan_modbus_registers_input(monkeypatch):
     TestField = type("TestField", (), {})()
@@ -61,7 +116,11 @@ async def test_scan_modbus_registers_input(monkeypatch):
     TestField.register = 1
 
     monkeypatch.setattr("custom_components.solvis_control.diagnostics.REGISTERS", [TestField])
-    monkeypatch.setattr(ModbusClient, "AsyncModbusTcpClient", lambda host, port: DummyClient(host, port))
+    monkeypatch.setattr(
+        diagnostics,
+        "AsyncModbusTcpClient",
+        dummy_client_cm,
+    )
 
     result = await scan_modbus_registers("127.0.0.1", 502, 1)
 
@@ -76,7 +135,11 @@ async def test_scan_modbus_registers_holding(monkeypatch):
     TestField.register = 2
 
     monkeypatch.setattr("custom_components.solvis_control.diagnostics.REGISTERS", [TestField])
-    monkeypatch.setattr(ModbusClient, "AsyncModbusTcpClient", lambda host, port: DummyClient(host, port))
+    monkeypatch.setattr(
+        diagnostics,
+        "AsyncModbusTcpClient",
+        dummy_client_cm,
+    )
 
     result = await scan_modbus_registers("127.0.0.1", 502, 2)
 
@@ -90,12 +153,11 @@ async def test_scan_modbus_registers_error(monkeypatch):
     TestField.address = 300
     TestField.register = 1
     monkeypatch.setattr("custom_components.solvis_control.diagnostics.REGISTERS", [TestField])
-
-    class ErrorClient(DummyClient):
-        async def read_input_registers(self, address, count):
-            return DummyResponse(True, [])
-
-    monkeypatch.setattr(ModbusClient, "AsyncModbusTcpClient", lambda host, port: ErrorClient(host, port))
+    monkeypatch.setattr(
+        diagnostics,
+        "AsyncModbusTcpClient",
+        error_client_cm,
+    )
 
     result = await scan_modbus_registers("127.0.0.1", 502, 1)
 
@@ -112,7 +174,11 @@ async def test_async_get_config_entry_diagnostics(monkeypatch):
     TestFieldHolding.register = 2
 
     monkeypatch.setattr("custom_components.solvis_control.diagnostics.REGISTERS", [TestFieldInput, TestFieldHolding])
-    monkeypatch.setattr(ModbusClient, "AsyncModbusTcpClient", lambda host, port: DummyClient(host, port))
+    monkeypatch.setattr(
+        diagnostics,
+        "AsyncModbusTcpClient",
+        dummy_client_cm,
+    )
 
     class DummyEntry:
         data = {
@@ -133,8 +199,11 @@ async def test_async_get_config_entry_diagnostics(monkeypatch):
 
 async def test_scan_modbus_registers_modbus_exception(monkeypatch):
     """Test that scan_modbus_registers captures a ModbusException and returns an error."""
-    monkeypatch.setattr(ModbusClient, "AsyncModbusTcpClient", lambda host, port: ExceptionClient())
-
+    monkeypatch.setattr(
+        diagnostics,
+        "AsyncModbusTcpClient",
+        error_read_client_cm,
+    )
     result = await scan_modbus_registers("127.0.0.1", 502, 1)
 
     assert "error" in result

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -37,6 +37,21 @@ from custom_components.solvis_control.const import (
     POLL_RATE_HIGH,
 )
 
+
+class DummyModbusCM:
+    def __init__(self, client):
+        self.client = client
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            self._client.close()
+        except:
+            pass
+
+
 # # # Tests for generate_device_info # # #
 
 
@@ -82,8 +97,8 @@ async def test_fetch_modbus_value_success(monkeypatch):
     dummy_client = DummyModbusClient([123])
     monkeypatch.setattr(
         helpers,
-        "ModbusClient",
-        type("DummyModbusModule", (), {"AsyncModbusTcpClient": lambda host, port: dummy_client}),
+        "create_modbus_client",
+        lambda host, port, device_version=None: DummyModbusCM(dummy_client),
     )
     result = await helpers.fetch_modbus_value(register=10, register_type=1, host="127.0.0.1", port=502)
 
@@ -94,34 +109,37 @@ async def test_fetch_modbus_value_success(monkeypatch):
 async def test_fetch_modbus_value_invalid_response(monkeypatch):
     host, port = "127.0.0.1", 502
     dummy_client = DummyModbusClient([])
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModbusModule", (), {"AsyncModbusTcpClient": lambda host, port: dummy_client}))
+    monkeypatch.setattr(
+        helpers,
+        "create_modbus_client",
+        lambda host, port, device_version=None: (_ for _ in ()).throw(ModbusException("Invalid response from Modbus for register 10")),
+    )
     with pytest.raises(ModbusException):
         await helpers.fetch_modbus_value(register=10, register_type=1, host="127.0.0.1", port=502)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  #
 async def test_fetch_modbus_value_connection_exception(monkeypatch):
+    host, port = "127.0.0.1", 502
     dummy_client = DummyModbusClient(registers=[123], raise_on_connect=True)
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModbusModule", (), {"AsyncModbusTcpClient": lambda host, port: dummy_client}))
+    monkeypatch.setattr(
+        helpers,
+        "create_modbus_client",
+        lambda host, port, device_version=None: (_ for _ in ()).throw(ConnectionException(f"Failed to connect to Modbus device at {host}:{port}")),
+    )
     with pytest.raises(ConnectionException):
         await helpers.fetch_modbus_value(register=10, register_type=1, host="127.0.0.1", port=502)
-
-
-@pytest.mark.asyncio
-async def test_fetch_modbus_value_no_modbus_client(monkeypatch):
-    host, port = "127.0.0.1", 502
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModule", (), {"AsyncModbusTcpClient": lambda host, port: None}))
-    with pytest.raises(ConnectionException) as excinfo:
-        await helpers.fetch_modbus_value(register=10, register_type=1, host=host, port=port)
-
-    assert f"Failed to initialize Modbus client for {host}:{port}" in str(excinfo.value)
 
 
 @pytest.mark.asyncio
 async def test_fetch_modbus_value_connect_fail(monkeypatch):
     host, port = "127.0.0.1", 502
     dummy_client = DummyModbusClient(connect_success=False)
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModule", (), {"AsyncModbusTcpClient": lambda host, port: dummy_client}))
+    monkeypatch.setattr(
+        helpers,
+        "create_modbus_client",
+        lambda host, port, device_version=None: (_ for _ in ()).throw(ConnectionException(f"Failed to connect to Modbus device at {host}:{port}")),
+    )
     with pytest.raises(ConnectionException) as excinfo:
         await helpers.fetch_modbus_value(register=10, register_type=1, host=host, port=port)
 
@@ -129,32 +147,34 @@ async def test_fetch_modbus_value_connect_fail(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_modbus_value_invalid_response(monkeypatch):
-    host, port = "127.0.0.1", 502
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModule", (), {"AsyncModbusTcpClient": lambda host, port: DummyModbusClient(registers=[])}))
-    with pytest.raises(ModbusException) as excinfo:
-        await helpers.fetch_modbus_value(register=10, register_type=1, host=host, port=port)
-
-    assert f"Invalid response from Modbus for register 10" in str(excinfo.value)
-
-
-@pytest.mark.asyncio
 async def test_fetch_modbus_value_holding_registers(monkeypatch):
-    host, port = "127.0.0.1", 502
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModule", (), {"AsyncModbusTcpClient": lambda host, port: DummyModbusClient(registers=[456])}))
-    result = await helpers.fetch_modbus_value(register=20, register_type=0, host=host, port=port)
-
+    dummy = DummyModbusClient([456])
+    monkeypatch.setattr(
+        helpers,
+        "create_modbus_client",
+        lambda host, port, device_version=None: DummyModbusCM(dummy),
+    )
+    result = await helpers.fetch_modbus_value(register=20, register_type=0, host="127.0.0.1", port=502)
     assert result == 456
 
 
 @pytest.mark.asyncio
-async def test_fetch_modbus_value_close_exception(monkeypatch, caplog):
-    host, port = "127.0.0.1", 502
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModule", (), {"AsyncModbusTcpClient": lambda host, port: DummyModbusClient(raise_on_close=True, registers=[789])}))
-    result = await helpers.fetch_modbus_value(register=10, register_type=1, host=host, port=port)
+async def test_fetch_modbus_value_error_response_is_error(monkeypatch):
+    # simuliert data.isError() == True
+    dummy_client = DummyModbusClient([1])
 
-    assert result == 789
-    assert "Error while closing Modbus connection: Close failed" in caplog.text
+    async def fake_read_input(address, count):
+        return DummyModbusResponse([1], error=True)
+
+    dummy_client.read_input_registers = fake_read_input
+    monkeypatch.setattr(
+        helpers,
+        "create_modbus_client",
+        lambda host, port, device_version=None: DummyModbusCM(dummy_client),
+    )
+    with pytest.raises(ModbusException) as excinfo:
+        await helpers.fetch_modbus_value(register=5, register_type=1, host="127.0.0.1", port=502)
+    assert "Invalid response from Modbus for register 5" in str(excinfo.value)
 
 
 # # # Tests for get_mac # # #
@@ -244,7 +264,6 @@ async def test_write_modbus_value_success():
     result = await helpers.write_modbus_value(dummy_modbus, address=10, value=123)
 
     assert result is True
-    assert dummy_modbus.called_close is True
 
 
 @pytest.mark.asyncio
@@ -253,7 +272,6 @@ async def test_write_modbus_value_error_response():
     result = await helpers.write_modbus_value(dummy_modbus, address=10, value=123)
 
     assert result is False
-    assert dummy_modbus.called_close is True
 
 
 @pytest.mark.asyncio
@@ -265,13 +283,11 @@ async def test_write_modbus_value_connection_exception():
     result = await helpers.write_modbus_value(dummy_modbus, address=10, value=123)
 
     assert result is False
-    assert dummy_modbus.called_close is True
 
 
 @pytest.mark.asyncio
 async def test_write_modbus_value_modbus_exception(monkeypatch):
     host, port = "127.0.0.1", 502
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModule", (), {"AsyncModbusTcpClient": lambda host, port: DummyModbusClient(raise_on_write=True, host=host, port=port)}))
     dummy = DummyModbusClient(raise_on_write=True, host=host, port=port)
     result = await helpers.write_modbus_value(dummy, address=10, value=123)
 
@@ -281,22 +297,10 @@ async def test_write_modbus_value_modbus_exception(monkeypatch):
 @pytest.mark.asyncio
 async def test_write_modbus_value_generic_exception(monkeypatch):
     host, port = "127.0.0.1", 502
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModule", (), {"AsyncModbusTcpClient": lambda host, port: DummyModbusClient(raise_generic_on_write=True, host=host, port=port)}))
     dummy = DummyModbusClient(raise_generic_on_write=True)
     result = await helpers.write_modbus_value(dummy, address=10, value=123)
 
     assert result is False
-
-
-@pytest.mark.asyncio
-async def test_write_modbus_value_close_exception(monkeypatch, caplog):
-    host, port = "127.0.0.1", 502
-    monkeypatch.setattr(helpers, "ModbusClient", type("DummyModule", (), {"AsyncModbusTcpClient": lambda host, port: DummyModbusClient(raise_on_close=True, registers=[789], host=host, port=port)}))
-    dummy = DummyModbusClient(raise_on_close=True, registers=[789])
-    result = await helpers.write_modbus_value(dummy, address=10, value=123)
-
-    assert result is True
-    assert "Error while closing Modbus connection: Close failed" in caplog.text
 
 
 # # # Tests for process_coordinator_data # # #
@@ -477,3 +481,27 @@ async def test_async_setup_solvis_entities_sensor(monkeypatch):
     assert sensor.state_class == "measurement"
     assert sensor.entity_category == EntityCategory.DIAGNOSTIC
     assert sensor.suggested_display_precision == 1
+
+
+# # # Tests for create_modbus_client # # #
+
+
+def test_create_modbus_client_device_version_2(monkeypatch):
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(helpers, "AsyncModbusTcpClient", DummyClient)
+    client = helpers.create_modbus_client("127.0.0.1", 502, device_version=2)
+
+    assert isinstance(client, DummyClient)
+    assert captured == {
+        "host": "127.0.0.1",
+        "port": 502,
+        "timeout": 6.0,
+        "retries": 3,
+        "reconnect_delay": 1.0,
+        "reconnect_delay_max": 5.0,
+    }

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -54,9 +54,8 @@ async def test_async_select_option(dummy_solvisselect_entity):
 
 @pytest.mark.asyncio
 async def test_async_select_option_connection_exception(dummy_solvisselect_entity):
-    """Test handling of a Modbus connection failure."""
+    """Test handling of a ConnectionException during modbus.write_register."""
     select_entity = dummy_solvisselect_entity(name="Test Entity", modbus_address=1, entity_id="select.test")
-    # Simulate a ConnectionException when writing the register.
     select_entity.coordinator.modbus.write_register = AsyncMock(side_effect=ConnectionException)
     await select_entity.async_select_option("1")
     select_entity.coordinator.modbus.write_register.assert_awaited_once()
@@ -64,7 +63,7 @@ async def test_async_select_option_connection_exception(dummy_solvisselect_entit
 
 @pytest.mark.asyncio
 async def test_async_select_option_modbus_failure(dummy_solvisselect_entity):
-    """Test async_select_option failure due to Modbus disconnection."""
+    """Test async_select_option failure due to error in modbus.write_register."""
     select_entity = dummy_solvisselect_entity(name="Test Entity", modbus_address=1, entity_id="select.test")
     select_entity.coordinator.modbus.connect = AsyncMock(return_value=False)
     error_response = MagicMock()
@@ -82,17 +81,6 @@ async def test_async_select_option_invalid_option(hass, mock_coordinator, mock_d
     with caplog.at_level(logging.WARNING):
         await select_entity.async_select_option("invalid")
     assert "Invalid option selected" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_async_select_option_connection_error(hass, mock_coordinator, mock_device_info, dummy_solvisselect_entity):
-    """Test handling connection error during option selection."""
-    select_entity = dummy_solvisselect_entity(host="host", name="test", enabled_by_default=True, modbus_address=100, entity_id="select.test")
-    mock_coordinator.modbus.connect = AsyncMock(return_value=False)
-    mock_coordinator.modbus.write_register = AsyncMock()
-    with patch("custom_components.solvis_control.select._LOGGER.error") as mock_logger:
-        await select_entity.async_select_option("1")
-        mock_logger.assert_called_with("[test] Failed to send option 1 to register 100")
 
 
 # # # Tests for handle_coordinator_update # # #


### PR DESCRIPTION
- Use `create_modbus_client` helper for client instantiation
- Await `connect()` during setup and raise `ConfigEntryNotReady` on failure
- Add SC2-device reconnection logic in coordinator with asyncio delays
- Ensure connection before polling using `ensure_connected` helper
- Close Modbus connection on unload and log debug/error messages
- Update `config_flow`’s `fetch_modbus_value` to accept `device_version`
- Load version from `manifest.json` and log integration version